### PR TITLE
Use finished_at as timestamp

### DIFF
--- a/src/magicpod.ts
+++ b/src/magicpod.ts
@@ -59,8 +59,8 @@ export function processBatchRunsData(batchRunsData: BatchRuns): void {
     const batch_run_number = batchRun.batch_run_number
     const test_setting_name = batchRun.test_setting_name
     const status = batchRun.status
-    const started_at = batchRun.started_at
-    const timestampSeconds = getUnixTimestampSeconds(started_at)
+    const finished_at = batchRun.finished_at
+    const timestampSeconds = getUnixTimestampSeconds(finished_at)
 
     submitMetircs(
       timestampSeconds,


### PR DESCRIPTION
As a limitation of datadog metrics, timestamps older than one hour cannot be sent.
If magicpod takes more than 1 hour to run, metrics will not be sent.
Use finished_at as the standard timestamp.