### PR TITLE
chore: Update release script with PR titles and links

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -30,13 +30,28 @@ git tag "${new_tag}"
 # 新しいタグをリモートリポジトリにプッシュ
 git push origin "${new_tag}"
 
+# 最新のタグと現在のブランチ間の全てのマージコミットを取得
+merge_commits=$(git log --merges --pretty=format:"%s" ${latest_tag}..HEAD)
+
+# マージコミットからプルリクエストの番号を取得し、それらのプルリクエストのタイトルとリンクを取得
+pr_titles_links=""
+while read -r line ; do
+    if [[ $line =~ Merge\ pull\ request\ #([0-9]*) ]] ; then
+        pr_number=${BASH_REMATCH[1]}
+        pr_info=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/chaspy/magicpod-datadog-action/pulls/${pr_number})
+        pr_title=$(echo $pr_info | jq -r .title)
+        pr_link=$(echo $pr_info | jq -r .html_url)
+        pr_titles_links="${pr_titles_links}\n${pr_title}: ${pr_link}"
+    fi
+done <<< "$merge_commits"
+
 # GitHub の API を使ってリリースを作成
 # GITHUB_TOKEN は環境変数として設定するか、直接スクリプトに記述してください
 repo_url="https://api.github.com/repos/chaspy/magicpod-datadog-action/releases"
 response=$(curl -s -X POST \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: token $GITHUB_TOKEN" \
-  -d "{\"tag_name\":\"$new_tag\",\"name\":\"Release $new_tag\"}" \
+  -d "{\"tag_name\":\"$new_tag\",\"name\":\"Release $new_tag\",\"body\":\"${pr_titles_links}\"}" \
   $repo_url)
 
 # リリースの作成に成功したか確認
@@ -45,3 +60,4 @@ if echo "$response" | grep -q '"id":'; then
 else
   echo "Failed to create release. Please check your GITHUB_TOKEN and repository settings."
 fi
+


### PR DESCRIPTION
Now GitHub Release only provides "compile" message (this is a commit message by release procedure)

![スクリーンショット 2023-07-02 11 37 46](https://github.com/chaspy/magicpod-datadog-action/assets/10370988/e7d3d1a2-9691-4c28-8a51-028e61dee007)
https://github.com/chaspy/magicpod-datadog-action/releases