### PR TITLE
fix: update grep command to lowercase

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -32,7 +32,7 @@ git push origin "${new_tag}"
 
 # Get all merge commits between the latest tag and the current branch
 merge_commits=$(git log --merges --pretty=format:"%s" "${latest_tag}"..main)
-renovate_commits=$(git log --oneline "${latest_tag}"..main | grep 'Update dependency')
+renovate_commits=$(git log --oneline "${latest_tag}"..main | grep 'update dependency')
 release_note_body="${merge_commits}\n${renovate_commits}"
 
 # Create a release using GitHub's API


### PR DESCRIPTION
now renovate commit leaves a message with lowercase

```
106aee3 chore(deps): update dependency typescript to v5.3.2
91eeefa chore(deps): update dependency eslint to v8.54.0
5170d50 fix(deps): update dependency @datadog/datadog-api-client to v1.19.0
```