### PR TITLE
Send human-readable label for displaying and/or grouping test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This is an action to send metrics of MagicPod to Datadog.
 ## Supported Tags
 
 - Batch Runs API: `batch_run_number`, `status`, `test_setting_name`, `organization_name`, `project_name`
-- Batch Run API: `batch_run_number`, `status`, `test_setting_name`, `organization_name`, `project_name`, `pattern_name`, `order`, `number`
+- Batch Run API: `batch_run_number`, `status`, `test_setting_name`, `organization_name`, `project_name`, `pattern_name`, `order`, `number`, `test_case.name`
 
 See [API Document](https://magic-pod.com/api/v1.0/doc/) for the details. (Models / BatchRun Section)
 

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -59,6 +59,7 @@ export interface BatchRunMetrics {
   pattern_name: string
   order: number
   number: number
+  test_case_name: string
 }
 
 export interface BatchRunsMetrics {

--- a/src/magicpod.ts
+++ b/src/magicpod.ts
@@ -54,6 +54,14 @@ interface Result {
   started_at: string
   finished_at: string
   data_patterns: any
+  test_case: TestCase
+}
+
+interface TestCase {
+  number: number
+  name: string
+  url: string
+  step_count: number
 }
 
 export async function getBatchRuns(inputs: Inputs): Promise<BatchRuns | null> {
@@ -142,6 +150,7 @@ export function processBatchRunData(batchRunData: BatchRun): void {
       const status = results.status
       const order = results.order
       const number = results.number
+      const test_case_name = results.test_case.name
 
       const metrics: BatchRunMetrics = {
         timestamp: timestampSeconds,
@@ -153,7 +162,8 @@ export function processBatchRunData(batchRunData: BatchRun): void {
         project_name: project_name,
         pattern_name: pattern_name,
         order: order,
-        number: number
+        number: number,
+        test_case_name: test_case_name
       }
 
       submitBatchRunMetrics(metrics)


### PR DESCRIPTION
Although we already have `number` retrieved with getBatchRun https://github.com/chaspy/magicpod-datadog-action/blob/9a2737bd75f8ac938d912f48e13c5dc2e6500599/src/magicpod.ts#L156 as a label to distinguish between the individual test cases, it would be nice to have a human-readable label to display in datadog dashboards.

I would like to send `test_case.name` as a human-readable label.

from: https://app.magicpod.com/api/v1.0/doc/
`GET` `/v1.0/{organization_name}/{project_name}/batch-run/{batch_run_number}/`
<img width="1027" alt="Screenshot 2024-10-19 at 16 40 49" src="https://github.com/user-attachments/assets/454738bf-c2c8-46ea-b72c-80fce7f99613">
