### PR TITLE
Submit acquired metrics to datadog as tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This is an action to send metrics of MagicPod to Datadog.
 ## Supported Tags
 
 - Batch Runs API: `batch_run_number`, `status`, `test_setting_name`, `organization_name`, `project_name`
-- Batch Run API: `batch_run_number`, `status`, `test_setting_name`, `organization_name`, `project_name`, `pattern_name`, `order`, `number`, `test_case.name`
+- Batch Run API: `batch_run_number`, `status`, `test_setting_name`, `organization_name`, `project_name`, `pattern_name`, `order`, `number`, `test_case_name`
 
 See [API Document](https://magic-pod.com/api/v1.0/doc/) for the details. (Models / BatchRun Section)
 

--- a/src/datadog.ts
+++ b/src/datadog.ts
@@ -122,7 +122,8 @@ export function submitBatchRunMetrics(metrics: BatchRunMetrics) {
     `project_name:${metrics.project_name}`,
     `pattern_name:${metrics.pattern_name}`,
     `order:${metrics.order}`,
-    `number:${metrics.number}`
+    `number:${metrics.number}`,
+    `test_case_name:${metrics.test_case_name}`
   ]
 
   const durationSecondParams = createSubmitMetricsRequest(


### PR DESCRIPTION
I'm sorry, https://github.com/chaspy/magicpod-datadog-action/pull/145 was missing the codes to actually submit the tags to datadog 🙏 